### PR TITLE
Fix #cl tag filtering to prevent UID assignment

### DIFF
--- a/Sources/ExportOtherRemindersCLI/main.swift
+++ b/Sources/ExportOtherRemindersCLI/main.swift
@@ -261,6 +261,11 @@ struct ExportOtherRemindersCLI {
                 text = String(text.dropFirst()).trimmingCharacters(in: .whitespaces)
             }
             
+            // Skip tasks with #cl tag (Obsidian-only checklist items)
+            if text.contains("#cl") {
+                continue
+            }
+            
             // Extract UUID if present
             if let id = extractIdFromNotes(text) {
                 // Remove the ID from the text
@@ -776,6 +781,12 @@ struct ExportOtherRemindersCLI {
             // Remove any leading "]" if present
             if cleanedLine.hasPrefix("]") {
                 cleanedLine = String(cleanedLine.dropFirst()).trimmingCharacters(in: .whitespaces)
+            }
+            
+            // Skip tasks with #cl tag (Obsidian-only checklist items)
+            if cleanedLine.contains("#cl") {
+                // Don't add this line back to the content since it's #cl only
+                continue
             }
             
             // Extract due date if present


### PR DESCRIPTION
## Summary

Fixes a critical bug where tasks tagged with `#cl` were incorrectly getting UIDs assigned, even though they were properly filtered from syncing to Apple Reminders.

## Problem

Tasks with `#cl` tag were intended to be Obsidian-only checklist items, but they were getting UIDs like:
- `- [ ] Send initial invitation #cl ^FA8D8503-40E4-45DC-8390-0D4DE2140F87`

This created orphaned IDs in the vault files without any corresponding Apple Reminders.

## Root Cause

The bug was in `findIncompleteTasks()` function where:
1. UIDs were assigned to ALL tasks first
2. `#cl` filtering only prevented syncing but left the UIDs in place

## Solution

- **RemindersSyncCore.swift**: Move `#cl` tag check BEFORE UID assignment in both single and multiple task processing paths
- **ExportOtherReminders**: Add consistent `#cl` filtering in `scanMarkdownTasks()` and `handleNewTasksWithoutID()` functions

## Test Plan

1. Delete `._RemindersMapping.json` to force fresh sync
2. Run sync on vault with `#cl` tasks
3. Verify `#cl` tasks don't get UIDs
4. Confirm `#cl` tasks remain Obsidian-only

## Result

Tasks with `#cl` tag now properly remain without IDs and don't sync to Apple Reminders, maintaining them as pure Obsidian checklist items as intended.