### PR TITLE
Fix space handling in task URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+RemindersSync is a Swift Package defined by `Package.swift`. Core sync logic lives in `Sources/RemindersSyncCore`, while CLI entrypoints reside in `Sources/<ToolName>CLI` (e.g., `Sources/SwiftRemindersCLI`). Tests for the core module are under `Tests/RemindersSyncCoreTests`. `install.sh` and `uninstall.sh` wrap release builds for system-wide installation, and `TestVault/` provides sample markdown data for manual verification.
+
+## Build, Test, and Development Commands
+- `swift build` compiles all targets and surfaces compiler diagnostics.
+- `swift run RemindersSync /path/to/vault` performs the primary two-way Obsidian↔︎Reminders sync; swap the target name to exercise `ScanVault`, `ExportOtherReminders`, `ReSyncReminders`, or `CleanUp`.
+- `swift run ExportOtherReminders --help` lists CLI flags, useful for discovering cleanup/reset options.
+- `swift test` executes `RemindersSyncCoreTests`; pair with `--parallel` for faster local feedback.
+- `sudo ./install.sh` installs release binaries into `/usr/local/bin`; rerun after dependency updates.
+
+## Coding Style & Naming Conventions
+Target Swift 5.9 and align with the Swift API Design Guidelines: four-space indentation, `UpperCamelCase` types, `lowerCamelCase` methods and properties. Prefer struct-based modeling in the core layer and isolate system integrations behind protocols for testability. Keep CLI targets suffixed with `CLI` to match existing module naming and expose user-facing commands through `swift run <ToolName>` or aliased binaries.
+
+## Testing Guidelines
+Extend the coverage-focused `Tests/RemindersSyncCoreTests` suite when adjusting sync logic; mirror behaviors with descriptive `test_<Scenario>_<Expectation>` methods. Use `swift test --enable-code-coverage` when validating substantial refactors, and review the generated report in Xcode. For integration changes, stage realistic markdown files in `TestVault/` and dry-run the relevant tool with `--cleanup` or `--help` before touching production data.
+
+## Commit & Pull Request Guidelines
+Write commits in the imperative mood (`Fix file path normalization`, `Add resync shortcut`) and keep subjects under ~50 characters; include a brief body explaining the motivation plus relevant CLI output when behavior changes. PRs should describe the impacted tools, list manual validation steps (`swift run RemindersSync TestVault`), link any tracked issues, and call out permissions considerations for reviewers. Request a CI run after major sync workflow adjustments to avoid regressions in release binaries.
+
+## Security & Configuration Tips
+Never hardcode vault paths, Apple IDs, or tokens; prefer arguments and environment variables consumed by the CLI wrappers. macOS will prompt for Reminders access on first run—advise contributors to use the native Terminal if third-party shells hide the dialog. Keep `install.sh` invocations scoped to trusted machines and audit resulting binaries before distribution.

--- a/Sources/RemindersSyncCore/RemindersSyncCore.swift
+++ b/Sources/RemindersSyncCore/RemindersSyncCore.swift
@@ -540,7 +540,9 @@ public func syncTasksFromVault(tasks: [ObsidianTask], eventStore: EKEventStore) 
         
         // Store the Obsidian ID in the notes
         var notes = [String]()
-        notes.append("obsidian://open?vault=\(task.vaultPath.components(separatedBy: "/").last ?? "")&file=\(task.filePath)")
+        if let obsidianURL = task.obsidianURL?.absoluteString {
+            notes.append(obsidianURL)
+        }
         notes.append("ID: \(task.id)")
         reminder.notes = notes.joined(separator: "\n")
         

--- a/Tests/RemindersSyncCoreTests/ObsidianURLTests.swift
+++ b/Tests/RemindersSyncCoreTests/ObsidianURLTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import RemindersSyncCore
+
+final class ObsidianURLTests: XCTestCase {
+    func testObsidianURLPercentEncodesSpaces() throws {
+        let task = ObsidianTask(
+            id: UUID().uuidString,
+            text: "Example task",
+            dueDate: nil,
+            filePath: "Projects/Weekly Notes.md",
+            vaultPath: "/Users/example/My Vault",
+            isCompleted: false
+        )
+        guard let url = task.obsidianURL else {
+            XCTFail("Expected obsidian URL to be produced")
+            return
+        }
+        let absoluteString = url.absoluteString
+        XCTAssertFalse(absoluteString.contains(" "), "URL should not contain raw spaces: \(absoluteString)")
+        XCTAssertTrue(absoluteString.contains("%20"), "URL should percent-encode spaces: \(absoluteString)")
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let vaultValue = components?.queryItems?.first(where: { $0.name == "vault" })?.value
+        let fileValue = components?.queryItems?.first(where: { $0.name == "file" })?.value
+        XCTAssertEqual(vaultValue, "My Vault")
+        XCTAssertEqual(fileValue, "Projects/Weekly Notes.md")
+    }
+    
+    func testObsidianURLEncodesReservedCharacters() throws {
+        let task = ObsidianTask(
+            id: UUID().uuidString,
+            text: "Example task",
+            dueDate: nil,
+            filePath: "Areas/Finance/Statement #1 (Draft).md",
+            vaultPath: "/Users/example/My Vault",
+            isCompleted: false
+        )
+        guard let url = task.obsidianURL else {
+            XCTFail("Expected obsidian URL to be produced")
+            return
+        }
+        let absoluteString = url.absoluteString
+        XCTAssertFalse(absoluteString.contains("#"), "URL should encode fragment character: \(absoluteString)")
+        XCTAssertTrue(absoluteString.contains("%23"), "URL should percent-encode #: \(absoluteString)")
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let fileValue = components?.queryItems?.first(where: { $0.name == "file" })?.value
+        XCTAssertEqual(fileValue, "Areas/Finance/Statement #1 (Draft).md")
+    }
+}

--- a/Tests/RemindersSyncCoreTests/ObsidianURLTests.swift
+++ b/Tests/RemindersSyncCoreTests/ObsidianURLTests.swift
@@ -18,6 +18,8 @@ final class ObsidianURLTests: XCTestCase {
         let absoluteString = url.absoluteString
         XCTAssertFalse(absoluteString.contains(" "), "URL should not contain raw spaces: \(absoluteString)")
         XCTAssertTrue(absoluteString.contains("%20"), "URL should percent-encode spaces: \(absoluteString)")
+        XCTAssertEqual(url.scheme, "obsidian")
+        XCTAssertEqual(url.host, "open")
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         let vaultValue = components?.queryItems?.first(where: { $0.name == "vault" })?.value
         let fileValue = components?.queryItems?.first(where: { $0.name == "file" })?.value
@@ -41,6 +43,8 @@ final class ObsidianURLTests: XCTestCase {
         let absoluteString = url.absoluteString
         XCTAssertFalse(absoluteString.contains("#"), "URL should encode fragment character: \(absoluteString)")
         XCTAssertTrue(absoluteString.contains("%23"), "URL should percent-encode #: \(absoluteString)")
+        XCTAssertEqual(url.scheme, "obsidian")
+        XCTAssertEqual(url.host, "open")
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         let fileValue = components?.queryItems?.first(where: { $0.name == "file" })?.value
         XCTAssertEqual(fileValue, "Areas/Finance/Statement #1 (Draft).md")


### PR DESCRIPTION
## Summary
- Fix URL parsing to handle spaces in task titles
- Add CODEX.md configuration file

## Details
Resolves spaces breaking URL detection in task titles. URL handling logic improved but URL objects not yet exposed for direct manipulation.

Closes https://github.com/VatsalSy/RemindersSync/issues/5