### PR TITLE
Ignore CLI agent files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,19 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-RemindersSync is a Swift Package defined by `Package.swift`. Core sync logic lives in `Sources/RemindersSyncCore`, while CLI entrypoints reside in `Sources/<ToolName>CLI` (e.g., `Sources/SwiftRemindersCLI`). Tests for the core module are under `Tests/RemindersSyncCoreTests`. `install.sh` and `uninstall.sh` wrap release builds for system-wide installation, and `TestVault/` provides sample markdown data for manual verification.
+RemindersSync is a Swift Package managed by `Package.swift`. Core sync logic and shared models live in `Sources/RemindersSyncCore`, while each CLI tool sits in `Sources/<ToolName>CLI` (e.g., `Sources/SwiftRemindersCLI`). Automated scripts such as `install.sh` and `uninstall.sh` wrap release builds for system installs, and `TestVault/` supplies sample Markdown reminders for manual dry runs. Contributor tooling and historical agent specs reside outside this tree; keep edits to this repo focused on the Swift package.
 
 ## Build, Test, and Development Commands
-- `swift build` compiles all targets and surfaces compiler diagnostics.
-- `swift run RemindersSync /path/to/vault` performs the primary two-way Obsidian↔︎Reminders sync; swap the target name to exercise `ScanVault`, `ExportOtherReminders`, `ReSyncReminders`, or `CleanUp`.
-- `swift run ExportOtherReminders --help` lists CLI flags, useful for discovering cleanup/reset options.
-- `swift test` executes `RemindersSyncCoreTests`; pair with `--parallel` for faster local feedback.
-- `sudo ./install.sh` installs release binaries into `/usr/local/bin`; rerun after dependency updates.
+Use `swift build` to compile all targets and surface compiler diagnostics. Run `swift run RemindersSync /path/to/vault` for the primary Obsidian↔︎Reminders sync; swap the target name to reach utilities like `ScanVault`, `ExportOtherReminders`, `ReSyncReminders`, or `CleanUp`. Execute `swift test` (optionally with `--parallel`) to exercise `RemindersSyncCoreTests`. Install release binaries with `sudo ./install.sh`; uninstall via `sudo ./uninstall.sh`. Favor `swift run ExportOtherReminders --help` to review cleanup and reset flags before destructive operations.
 
 ## Coding Style & Naming Conventions
-Target Swift 5.9 and align with the Swift API Design Guidelines: four-space indentation, `UpperCamelCase` types, `lowerCamelCase` methods and properties. Prefer struct-based modeling in the core layer and isolate system integrations behind protocols for testability. Keep CLI targets suffixed with `CLI` to match existing module naming and expose user-facing commands through `swift run <ToolName>` or aliased binaries.
+Target Swift 5.9. Follow four-space indentation and the Swift API Design Guidelines: `UpperCamelCase` for types, `lowerCamelCase` for functions and properties. Keep CLI targets suffixed with `CLI`, and favor structs plus protocol-backed integrations for testability. Avoid hardcoded absolute paths; accept vault locations via arguments.
 
 ## Testing Guidelines
-Extend the coverage-focused `Tests/RemindersSyncCoreTests` suite when adjusting sync logic; mirror behaviors with descriptive `test_<Scenario>_<Expectation>` methods. Use `swift test --enable-code-coverage` when validating substantial refactors, and review the generated report in Xcode. For integration changes, stage realistic markdown files in `TestVault/` and dry-run the relevant tool with `--cleanup` or `--help` before touching production data.
+Unit coverage lives under `Tests/RemindersSyncCoreTests` with `test_<Scenario>_<Expectation>` naming. Add focused cases whenever sync logic changes, and prefer deterministic fixtures. For larger shifts, run `swift test --enable-code-coverage` and inspect results in Xcode. Validate integration flows against `TestVault/` before touching live data, and document any manual reproduction steps in PRs.
 
 ## Commit & Pull Request Guidelines
-Write commits in the imperative mood (`Fix file path normalization`, `Add resync shortcut`) and keep subjects under ~50 characters; include a brief body explaining the motivation plus relevant CLI output when behavior changes. PRs should describe the impacted tools, list manual validation steps (`swift run RemindersSync TestVault`), link any tracked issues, and call out permissions considerations for reviewers. Request a CI run after major sync workflow adjustments to avoid regressions in release binaries.
+Write imperative commit subjects under ~50 characters (e.g., `Add resync shortcut`). Summaries should mention motivation plus relevant CLI output when behavior changes. Pull requests must describe affected tools, list validation commands (`swift run RemindersSync TestVault`), link issues, and flag permissions or migration steps. Confirm CI’s Agent Consistency Check passes before requesting review.
 
 ## Security & Configuration Tips
-Never hardcode vault paths, Apple IDs, or tokens; prefer arguments and environment variables consumed by the CLI wrappers. macOS will prompt for Reminders access on first run—advise contributors to use the native Terminal if third-party shells hide the dialog. Keep `install.sh` invocations scoped to trusted machines and audit resulting binaries before distribution.
+Never commit vault paths, Apple IDs, or credentials. Prefer environment variables and CLI flags for secrets. macOS prompts for Reminders access on first run—use the native Terminal so the dialog appears. Audit release binaries after running `install.sh`, and restrict distribution to trusted environments.

--- a/Sources/CleanUpCLI/main.swift
+++ b/Sources/CleanUpCLI/main.swift
@@ -68,20 +68,22 @@ struct CleanUpCLI {
     
     static func removeCompletedTasksFromVault(vaultPath: String) throws -> Int {
         let fileManager = FileManager.default
+        let vaultURL = URL(fileURLWithPath: vaultPath)
         let enumerator = fileManager.enumerator(
-            at: URL(fileURLWithPath: vaultPath),
+            at: vaultURL,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
         )
-        
+
         let completedTaskPattern = #"^\s*- \[[xX]\] .+$"#
         let completedRegex = try NSRegularExpression(pattern: completedTaskPattern, options: .anchorsMatchLines)
-        
+
         var totalRemoved = 0
         var filesProcessed = 0
-        
+
         while let fileURL = enumerator?.nextObject() as? URL {
-            let relativePath = fileURL.path.replacingOccurrences(of: vaultPath, with: "")
+            // Get safe relative path (already normalized)
+            let relativePath = safeRelativePath(fileURL: fileURL, vaultURL: vaultURL)
 
             // Skip files that should be excluded
             guard !shouldExcludeFile(fileURL: fileURL, relativePath: relativePath) else {

--- a/Sources/CleanUpCLI/main.swift
+++ b/Sources/CleanUpCLI/main.swift
@@ -85,6 +85,8 @@ struct CleanUpCLI {
             guard fileURL.pathExtension == "md",
                   !fileURL.lastPathComponent.hasPrefix("._"),
                   fileURL.lastPathComponent != "_AppleReminders.md",
+                  fileURL.lastPathComponent != "CLAUDE.md",
+                  fileURL.lastPathComponent != "AGENTS.md",
                   !relativePath.contains("/Templates/"),
                   !relativePath.contains("/aiprompts/") else {
                 continue

--- a/Sources/CleanUpCLI/main.swift
+++ b/Sources/CleanUpCLI/main.swift
@@ -82,13 +82,9 @@ struct CleanUpCLI {
         
         while let fileURL = enumerator?.nextObject() as? URL {
             let relativePath = fileURL.path.replacingOccurrences(of: vaultPath, with: "")
-            guard fileURL.pathExtension == "md",
-                  !fileURL.lastPathComponent.hasPrefix("._"),
-                  fileURL.lastPathComponent != "_AppleReminders.md",
-                  fileURL.lastPathComponent != "CLAUDE.md",
-                  fileURL.lastPathComponent != "AGENTS.md",
-                  !relativePath.contains("/Templates/"),
-                  !relativePath.contains("/aiprompts/") else {
+
+            // Skip files that should be excluded
+            guard !shouldExcludeFile(fileURL: fileURL, relativePath: relativePath) else {
                 continue
             }
             

--- a/Sources/CleanUpCLI/main.swift
+++ b/Sources/CleanUpCLI/main.swift
@@ -20,6 +20,13 @@ struct CleanUpCLI {
         }
         
         let vaultPath = (args[1] as NSString).expandingTildeInPath
+        do {
+            try validateVaultPath(vaultPath)
+        } catch {
+            print("Error: \(error.localizedDescription)")
+            exit(1)
+        }
+
         let eventStore = EKEventStore()
         
         do {

--- a/Sources/ExportOtherRemindersCLI/main.swift
+++ b/Sources/ExportOtherRemindersCLI/main.swift
@@ -120,7 +120,14 @@ struct ExportOtherRemindersCLI {
                 exit(1)
             }
             
-            let vaultPath = CommandLine.arguments[1]
+            let vaultPath = (CommandLine.arguments[1] as NSString).expandingTildeInPath
+            do {
+                try validateVaultPath(vaultPath)
+            } catch {
+                print("Error: \(error.localizedDescription)")
+                exit(1)
+            }
+
             let eventStore = EKEventStore()
             try await requestRemindersAccess(eventStore: eventStore)
             

--- a/Sources/ReSyncRemindersCLI/main.swift
+++ b/Sources/ReSyncRemindersCLI/main.swift
@@ -45,18 +45,14 @@ let enumerator = fileManager.enumerator(
 )
 
 while let fileURL = enumerator?.nextObject() as? URL {
-    // Skip non-markdown files and special files
+    // Calculate relative path for exclusion checks
     let vaultURL = URL(fileURLWithPath: vaultPath)
-    let relativePath = fileURL.path.hasPrefix(vaultURL.path) 
+    let relativePath = fileURL.path.hasPrefix(vaultURL.path)
         ? String(fileURL.path.dropFirst(vaultURL.path.count))
         : fileURL.path
-    guard fileURL.pathExtension == "md",
-          !fileURL.lastPathComponent.hasPrefix("._"),
-          fileURL.lastPathComponent != "_AppleReminders.md",
-          fileURL.lastPathComponent != "CLAUDE.md",
-          fileURL.lastPathComponent != "AGENTS.md",
-          !relativePath.contains("/Templates/"),
-          !relativePath.contains("/aiprompts/") else {
+
+    // Skip files that should be excluded
+    guard !shouldExcludeFile(fileURL: fileURL, relativePath: relativePath) else {
         continue
     }
     

--- a/Sources/ReSyncRemindersCLI/main.swift
+++ b/Sources/ReSyncRemindersCLI/main.swift
@@ -53,6 +53,8 @@ while let fileURL = enumerator?.nextObject() as? URL {
     guard fileURL.pathExtension == "md",
           !fileURL.lastPathComponent.hasPrefix("._"),
           fileURL.lastPathComponent != "_AppleReminders.md",
+          fileURL.lastPathComponent != "CLAUDE.md",
+          fileURL.lastPathComponent != "AGENTS.md",
           !relativePath.contains("/Templates/"),
           !relativePath.contains("/aiprompts/") else {
         continue

--- a/Sources/ReSyncRemindersCLI/main.swift
+++ b/Sources/ReSyncRemindersCLI/main.swift
@@ -38,15 +38,15 @@ var idsRemoved = 0
 
 print("Preparing vault for fresh sync: \(vaultPath)")
 
+let vaultURL = URL(fileURLWithPath: vaultPath)
 let enumerator = fileManager.enumerator(
-    at: URL(fileURLWithPath: vaultPath),
+    at: vaultURL,
     includingPropertiesForKeys: [.isRegularFileKey],
     options: [.skipsHiddenFiles]
 )
 
 while let fileURL = enumerator?.nextObject() as? URL {
     // Calculate relative path for exclusion checks
-    let vaultURL = URL(fileURLWithPath: vaultPath)
     let relativePath = fileURL.path.hasPrefix(vaultURL.path)
         ? String(fileURL.path.dropFirst(vaultURL.path.count))
         : fileURL.path

--- a/Sources/ReSyncRemindersCLI/main.swift
+++ b/Sources/ReSyncRemindersCLI/main.swift
@@ -15,6 +15,13 @@ if args.count != 2 {
 }
 
 let vaultPath = (args[1] as NSString).expandingTildeInPath
+do {
+    try validateVaultPath(vaultPath)
+} catch {
+    print("Error: \(error.localizedDescription)")
+    exit(1)
+}
+
 let fileManager = FileManager.default
 
 // Regex patterns
@@ -46,10 +53,8 @@ let enumerator = fileManager.enumerator(
 )
 
 while let fileURL = enumerator?.nextObject() as? URL {
-    // Calculate relative path for exclusion checks
-    let relativePath = fileURL.path.hasPrefix(vaultURL.path)
-        ? String(fileURL.path.dropFirst(vaultURL.path.count))
-        : fileURL.path
+    // Calculate relative path using centralized helper (normalized, no leading slash)
+    let relativePath = safeRelativePath(fileURL: fileURL, vaultURL: vaultURL)
 
     // Skip files that should be excluded
     guard !shouldExcludeFile(fileURL: fileURL, relativePath: relativePath) else {

--- a/Sources/RemindersSyncCore/RemindersSyncCore.swift
+++ b/Sources/RemindersSyncCore/RemindersSyncCore.swift
@@ -218,6 +218,8 @@ public func findIncompleteTasks(in vaultPath: String) throws -> [ObsidianTask] {
         
         guard fileURL.pathExtension == "md",
               fileURL.lastPathComponent != "_AppleReminders.md",
+              fileURL.lastPathComponent != "CLAUDE.md",
+              fileURL.lastPathComponent != "AGENTS.md",
               !fileURL.lastPathComponent.hasPrefix("._"),
               !relativePath.contains("/Templates/"),
               !relativePath.contains("/aiprompts/") else {
@@ -426,6 +428,8 @@ public func findCompletedTasks(in vaultPath: String) throws -> [ObsidianTask] {
         
         guard fileURL.pathExtension == "md",
               fileURL.lastPathComponent != "_AppleReminders.md",
+              fileURL.lastPathComponent != "CLAUDE.md",
+              fileURL.lastPathComponent != "AGENTS.md",
               !fileURL.lastPathComponent.hasPrefix("._"),
               !relativePath.contains("/Templates/"),
               !relativePath.contains("/aiprompts/") else {
@@ -814,6 +818,8 @@ public func findAllTasks(in vaultPath: String) throws -> [ObsidianTask] {
     while let fileURL = enumerator?.nextObject() as? URL {
         guard fileURL.pathExtension == "md",
               fileURL.lastPathComponent != "_AppleReminders.md",
+              fileURL.lastPathComponent != "CLAUDE.md",
+              fileURL.lastPathComponent != "AGENTS.md",
               !fileURL.lastPathComponent.hasPrefix("._") else {
             continue
         }
@@ -1086,6 +1092,8 @@ public func cleanupTaskIds(in vaultPath: String) throws {
     while let fileURL = enumerator?.nextObject() as? URL {
         guard fileURL.pathExtension == "md",
               fileURL.lastPathComponent != "_AppleReminders.md",
+              fileURL.lastPathComponent != "CLAUDE.md",
+              fileURL.lastPathComponent != "AGENTS.md",
               !fileURL.lastPathComponent.hasPrefix("._") else {
             continue
         }

--- a/Sources/RemindersSyncCore/RemindersSyncCore.swift
+++ b/Sources/RemindersSyncCore/RemindersSyncCore.swift
@@ -124,7 +124,7 @@ public struct CLIOptions {
     
     public static func parse() -> CLIOptions {
         let args = CommandLine.arguments
-        
+
         if args.count != 2 {
             print("Usage: \(args[0]) <path-to-obsidian-vault>")
             print("Example: \(args[0]) ~/Documents/MyVault")
@@ -133,8 +133,16 @@ public struct CLIOptions {
             print("- Export reminders to: <vault>/_AppleReminders.md")
             exit(1)
         }
-        
-        return CLIOptions(vaultPath: (args[1] as NSString).expandingTildeInPath)
+
+        let expandedPath = (args[1] as NSString).expandingTildeInPath
+        do {
+            try validateVaultPath(expandedPath)
+        } catch {
+            print("Error: \(error.localizedDescription)")
+            exit(1)
+        }
+
+        return CLIOptions(vaultPath: expandedPath)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add functionality to ignore CLI agent files during vault scanning

## Changes Made
- Update CleanUp and ReSyncReminders to exclude agent files
- Add isAgentFile function to filter out .claude/, .gemini/, .codex/ directories and related files